### PR TITLE
AEA 1573 HAPI restful

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-reflect</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <java.version>1.8</java.version>
         <kotlin.version>1.3.72</kotlin.version>
+        <hapifhir.version>5.1.0</hapifhir.version>
     </properties>
 
     <dependencies>
@@ -55,22 +56,27 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-base</artifactId>
-            <version>5.1.0</version>
+            <version>${hapifhir.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ca.uhn.hapi.fhir</groupId>
+            <artifactId>hapi-fhir-server</artifactId>
+            <version>${hapifhir.version}</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-client</artifactId>
-            <version>5.1.0</version>
+            <version>${hapifhir.version}</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r5</artifactId>
-            <version>5.1.0</version>
+            <version>${hapifhir.version}</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-structures-r4</artifactId>
-            <version>5.1.0</version>
+            <version>${hapifhir.version}</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
@@ -80,12 +86,12 @@
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation</artifactId>
-            <version>5.1.0</version>
+            <version>${hapifhir.version}</version>
         </dependency>
         <dependency>
             <groupId>ca.uhn.hapi.fhir</groupId>
             <artifactId>hapi-fhir-validation-resources-r4</artifactId>
-            <version>5.1.0</version>
+            <version>${hapifhir.version}</version>
         </dependency>
         <dependency>
             <groupId>io.github.microutils</groupId>

--- a/src/main/kotlin/com/example/fhirvalidator/FhirValidatorApplication.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/FhirValidatorApplication.kt
@@ -1,9 +1,12 @@
 package com.example.fhirvalidator
 
+import com.example.fhirvalidator.configuration.IgProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
+@EnableConfigurationProperties(IgProperties::class)
 class FhirValidatorApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/example/fhirvalidator/configuration/ApplicationConfiguration.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/configuration/ApplicationConfiguration.kt
@@ -2,23 +2,48 @@ package com.example.fhirvalidator.configuration
 
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.parser.LenientErrorHandler
+import ca.uhn.fhir.parser.StrictErrorHandler
+import com.example.fhirvalidator.server.FHIRRestfulServer
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.web.servlet.ServletRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.context.support.GenericWebApplicationContext
+import javax.servlet.Servlet
 
 @Configuration
 class ApplicationConfiguration {
+
+    @Autowired
+    lateinit var applicationContext: GenericWebApplicationContext
+
     @Bean
     fun fhirContext(): FhirContext {
-        val lenientErrorHandler = LenientErrorHandler()
-        lenientErrorHandler.isErrorOnInvalidValue = false
+        // IG is no l
+        val strictErrorHandler = StrictErrorHandler()
+        ///lenientErrorHandler.isErrorOnInvalidValue = false
         val fhirContext = FhirContext.forR4()
-        fhirContext.setParserErrorHandler(lenientErrorHandler)
+        fhirContext.setParserErrorHandler(strictErrorHandler)
         return fhirContext
     }
 
     @Bean
     fun restTemplate(): RestTemplate {
         return RestTemplate()
+    }
+
+
+
+    @Bean
+    fun FHIRServerR4RegistrationBean(ctx: FhirContext? ): ServletRegistrationBean<*>? {
+        val registration: ServletRegistrationBean<*> = ServletRegistrationBean<Servlet?>(FHIRRestfulServer(ctx, applicationContext), "/R4/*")
+        val params: MutableMap<String, String> = HashMap()
+        params["FhirVersion"] = "R4"
+        params["ImplementationDescription"] = "FHIR Validation Server"
+        registration.initParameters = params
+        registration.setName("FhirR4Servlet")
+        registration.setLoadOnStartup(1)
+        return registration
     }
 }

--- a/src/main/kotlin/com/example/fhirvalidator/configuration/IgProperties.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/configuration/IgProperties.kt
@@ -1,0 +1,10 @@
+package com.example.fhirvalidator.configuration
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "ig")
+class IgProperties(var packageDownload : Boolean) {
+
+}

--- a/src/main/kotlin/com/example/fhirvalidator/configuration/PackageConfiguration.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/configuration/PackageConfiguration.kt
@@ -3,10 +3,15 @@ package com.example.fhirvalidator.configuration
 import com.example.fhirvalidator.model.SimplifierPackage
 import com.fasterxml.jackson.databind.ObjectMapper
 import mu.KLogging
+import org.hl7.fhir.exceptions.FHIRException
+import org.hl7.fhir.utilities.cache.FilesystemPackageCacheManager
 import org.hl7.fhir.utilities.cache.NpmPackage
+import org.hl7.fhir.utilities.cache.ToolsVersion
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ClassPathResource
+import java.io.InputStream
+import java.net.URL
 import java.util.*
 import kotlin.streams.toList
 
@@ -18,10 +23,60 @@ class PackageConfiguration(val objectMapper: ObjectMapper) {
     fun getPackages(): List<NpmPackage> {
         val inputStream = ClassPathResource("manifest.json").inputStream
         val packages = objectMapper.readValue(inputStream, Array<SimplifierPackage>::class.java)
-        return Arrays.stream(packages)
+        var packageList : MutableList<NpmPackage> = ArrayList<NpmPackage>();
+        packageList.addAll(Arrays.stream(packages)
+            .filter{it.download == false}
             .map { "${it.packageName}-${it.version}.tgz" }
             .map { ClassPathResource(it).inputStream }
             .map { NpmPackage.fromPackage(it) }
-            .toList()
+            .toList())
+        val pcm = FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
+        packageList.addAll(Arrays.stream(packages)
+            .filter{it.download == true}
+            .map { getGetPackage(pcm, it.packageName,  it.version, it.download) }
+            .toList())
+
+        return packageList
+    }
+
+    fun getGetPackage(pcm : FilesystemPackageCacheManager, packageName : String, version : String, download : Boolean? ) : NpmPackage {
+        if (download != null && !download) {
+            return pcm.loadPackage( packageName,  version)
+        } else {
+            return getPackageFromUrl(pcm,packageName, version )
+        }
+    }
+
+    @Throws(Exception::class)
+    private fun getPackageFromUrl(pcm: FilesystemPackageCacheManager, packageName: String, version: String ): NpmPackage {
+        val stream: InputStream?
+        try {
+            val url = "https://packages.simplifier.net/${packageName}/-/${packageName}-${version}.tgz"
+            println(url)
+            if (url.contains(".tgz")) {
+                stream = fetchFromUrlSpecific(url, true)
+                if (stream != null) {
+                    return pcm.addPackageToCache(packageName, version, stream, url)
+                }
+            }
+        } catch (ex: Exception) {
+            println("ERROR")
+        }
+        throw FHIRException("Package not found")
+    }
+
+    @Throws(FHIRException::class)
+    private fun fetchFromUrlSpecific(source: String, optional: Boolean): InputStream? {
+        return try {
+            val url = URL(source)
+            val c = url.openConnection()
+            c.getInputStream()
+        } catch (var5: Exception) {
+            if (optional) {
+                null
+            } else {
+                throw FHIRException(var5.message, var5)
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/example/fhirvalidator/configuration/PackageConfiguration.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/configuration/PackageConfiguration.kt
@@ -20,20 +20,20 @@ class PackageConfiguration(val objectMapper: ObjectMapper) {
     companion object : KLogging()
 
     @Bean
-    fun getPackages(): List<NpmPackage> {
+    fun getPackages(applicationProperties: IgProperties): List<NpmPackage> {
         val inputStream = ClassPathResource("manifest.json").inputStream
         val packages = objectMapper.readValue(inputStream, Array<SimplifierPackage>::class.java)
         var packageList : MutableList<NpmPackage> = ArrayList<NpmPackage>();
         packageList.addAll(Arrays.stream(packages)
-            .filter{it.download == false}
+            .filter{applicationProperties.packageDownload == false}
             .map { "${it.packageName}-${it.version}.tgz" }
             .map { ClassPathResource(it).inputStream }
             .map { NpmPackage.fromPackage(it) }
             .toList())
         val pcm = FilesystemPackageCacheManager(true, ToolsVersion.TOOLS_VERSION);
         packageList.addAll(Arrays.stream(packages)
-            .filter{it.download == true}
-            .map { getGetPackage(pcm, it.packageName,  it.version, it.download) }
+            .filter{applicationProperties.packageDownload == true}
+            .map { getGetPackage(pcm, it.packageName,  it.version, applicationProperties.packageDownload) }
             .toList())
 
         return packageList

--- a/src/main/kotlin/com/example/fhirvalidator/controller/StatusController.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/controller/StatusController.kt
@@ -3,6 +3,7 @@ package com.example.fhirvalidator.controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
+
 @RestController
 class StatusController {
     @GetMapping("_status")
@@ -10,3 +11,20 @@ class StatusController {
         return "Validator is alive"
     }
 }
+
+/*
+@Component
+class StatusController {
+
+    @Operation(name = "status", manualResponse=true, manualRequest=true)
+    @Throws(IOException::class)
+    fun validate(theServletRequest: HttpServletRequest, theServletResponse: HttpServletResponse) {
+        //val contentType = theServletRequest.contentType
+        //val bytes: ByteArray = IOUtils.toByteArray(theServletRequest.inputStream)
+        theServletResponse.contentType = "text/plain"
+        theServletResponse.writer.write("Validator is alive")
+        theServletResponse.writer.close()
+    }
+}
+
+ */

--- a/src/main/kotlin/com/example/fhirvalidator/controller/ValidateController.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/controller/ValidateController.kt
@@ -2,26 +2,35 @@ package com.example.fhirvalidator.controller
 
 import ca.uhn.fhir.context.FhirContext
 import ca.uhn.fhir.parser.DataFormatException
+import ca.uhn.fhir.rest.annotation.ResourceParam
+import ca.uhn.fhir.rest.annotation.Validate
+import ca.uhn.fhir.rest.api.MethodOutcome
+import ca.uhn.fhir.rest.api.ValidationModeEnum
 import ca.uhn.fhir.validation.FhirValidator
 import com.example.fhirvalidator.service.CapabilityStatementApplier
 import com.example.fhirvalidator.service.MessageDefinitionApplier
 import com.example.fhirvalidator.util.createOperationOutcome
 import mu.KLogging
 import org.hl7.fhir.instance.model.api.IBaseOperationOutcome
+import org.hl7.fhir.instance.model.api.IBaseResource
+import org.springframework.stereotype.Component
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
+import java.net.URLDecoder
+import javax.servlet.http.HttpServletRequest
 
-@RestController
-class ValidateController(
-    private val fhirContext: FhirContext,
+@Component
+class ValidateController
+    (private val fhirContext: FhirContext,
     private val validator: FhirValidator,
     private val messageDefinitionApplier: MessageDefinitionApplier,
     private val capabilityStatementApplier: CapabilityStatementApplier
 ) {
     companion object : KLogging()
 
+            /*
     @PostMapping("/\$validate", produces = ["application/json", "application/fhir+json"])
     fun validate(
         @RequestBody input: String,
@@ -31,11 +40,34 @@ class ValidateController(
         val result = parseAndValidateResource(input)
         requestId?.let { logger.info("finished processing message $it") }
         return fhirContext.newJsonParser().encodeResourceToString(result)
+    }*/
+
+    @Validate
+    fun validate(theServletRequest : HttpServletRequest, @ResourceParam resource : IBaseResource,
+                 @Validate.Profile theProfile : String?,
+                 @Validate.Mode theMode : ValidationModeEnum?
+    ) : MethodOutcome {
+        // Probably a better way of doing this. Presume @Validate.Profile is to support the Parameter POST operation
+        var profile : String? = theProfile
+        if (theServletRequest.queryString != null && theProfile == null) {
+            val query_pairs: MutableMap<String, String> = LinkedHashMap()
+            val query = theServletRequest.queryString
+            val pairs = query.split("&".toRegex()).toTypedArray()
+            for (pair in pairs) {
+                val idx = pair.indexOf("=")
+                query_pairs[URLDecoder.decode(pair.substring(0, idx), "UTF-8")] = URLDecoder.decode(pair.substring(idx + 1), "UTF-8")
+            }
+            profile = query_pairs["profile"]
+        }
+        val operationOutcome = parseAndValidateResource(resource, profile)
+        val methodOutcome = MethodOutcome()
+        methodOutcome.setOperationOutcome(operationOutcome)
+        return methodOutcome;
     }
 
-    private fun parseAndValidateResource(input: String): IBaseOperationOutcome {
+    private fun parseAndValidateResource(inputResource : IBaseResource, theProfile : String?): IBaseOperationOutcome {
         return try {
-            val inputResource = fhirContext.newJsonParser().parseResource(input)
+            // KGM 18/7/2021 val inputResource = fhirContext.newJsonParser().parseResource(input)
             val messageDefinitionErrors = messageDefinitionApplier.applyMessageDefinition(inputResource)
             capabilityStatementApplier.applyCapabilityStatementProfiles(inputResource)
             messageDefinitionErrors ?: validator.validateWithResult(inputResource).toOperationOutcome()

--- a/src/main/kotlin/com/example/fhirvalidator/model/SimplifierPackage.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/model/SimplifierPackage.kt
@@ -1,3 +1,3 @@
 package com.example.fhirvalidator.model
 
-data class SimplifierPackage(var packageName: String, val version: String)
+data class  SimplifierPackage(var packageName: String, val version: String, val download: Boolean?)

--- a/src/main/kotlin/com/example/fhirvalidator/model/SimplifierPackage.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/model/SimplifierPackage.kt
@@ -1,3 +1,3 @@
 package com.example.fhirvalidator.model
 
-data class  SimplifierPackage(var packageName: String, val version: String, val download: Boolean?)
+data class  SimplifierPackage(var packageName: String, val version: String)

--- a/src/main/kotlin/com/example/fhirvalidator/server/FHIRRestfulServer.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/server/FHIRRestfulServer.kt
@@ -1,0 +1,32 @@
+package com.example.fhirvalidator.server
+
+import ca.uhn.fhir.context.FhirContext
+import ca.uhn.fhir.rest.api.EncodingEnum
+import ca.uhn.fhir.rest.server.RestfulServer
+import com.example.fhirvalidator.controller.StatusController
+import com.example.fhirvalidator.controller.ValidateController
+import org.springframework.context.ApplicationContext
+import java.util.*
+
+
+class FHIRRestfulServer(theCtx: FhirContext?, applicationContext: ApplicationContext) : RestfulServer(theCtx) {
+
+    val ctx= theCtx;
+    val applicationContext = applicationContext
+
+    @SuppressWarnings("unchecked")
+    override fun initialize() {
+        super.initialize()
+        fhirContext = ctx;
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+
+        val plainProviders: MutableList<Any?> = ArrayList()
+        plainProviders.add(applicationContext.getBean(ValidateController::class.java))
+
+        registerProviders(plainProviders)
+
+        isDefaultPrettyPrint = true
+        defaultResponseEncoding = EncodingEnum.JSON
+    }
+
+}

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,17 +1,14 @@
 [
   {
     "packageName": "uk.nhsdigital.medicines.r4",
-    "version": "2.1.14-alpha",
-    "download": false
+    "version": "2.1.14-alpha"
   },
   {
     "packageName": "uk.nhsdigital.r4",
-    "version": "2.1.16-discovery",
-    "download": false
+    "version": "2.1.16-discovery"
   },
   {
     "packageName": "UK.Core.r4.v2",
-    "version": "2.0.8",
-    "download": false
+    "version": "2.0.8"
   }
 ]

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,18 +1,17 @@
 [
   {
     "packageName": "uk.nhsdigital.medicines.r4",
-    "version": "2.1.14-alpha"
+    "version": "2.1.14-alpha",
+    "download": true
   },
   {
     "packageName": "uk.nhsdigital.r4",
-    "version": "2.1.16-discovery"
-  },
-  {
-    "packageName": "uk.nhsdigital.clinical.r4",
-    "version": "2.1.0-dev"
+    "version": "2.1.16-discovery",
+    "download": true
   },
   {
     "packageName": "UK.Core.r4.v2",
-    "version": "2.0.8"
+    "version": "2.0.8",
+    "download": true
   }
 ]

--- a/src/test/kotlin/com/example/fhirvalidator/FhirValidatorApplicationTests.kt
+++ b/src/test/kotlin/com/example/fhirvalidator/FhirValidatorApplicationTests.kt
@@ -62,7 +62,12 @@ class FhirValidatorApplicationTests(@Autowired val restTemplate: TestRestTemplat
 
     private fun hasErrors(operationOutcome: OperationOutcome) : Boolean {
         operationOutcome.issue.forEach{
-            if (it.severity == OperationOutcome.IssueSeverity.ERROR) return true
+            if (it.severity == OperationOutcome.IssueSeverity.ERROR) {
+                logger.error("Severity {} Diagnostics {}", it.severity, it.diagnostics)
+                return true
+            } else {
+                logger.info("Severity {} Diagnostics {}", it.severity, it.diagnostics)
+            }
         }
         return false
     }
@@ -79,7 +84,7 @@ class FhirValidatorApplicationTests(@Autowired val restTemplate: TestRestTemplat
 
         val resource = getFileResourceXML("MedicationRequest-missingSNOMEDMedcation.xml")
         val out: ResponseEntity<*>? =
-            validateResource(ctx.newJsonParser().encodeResourceToString(resource), MediaType.APPLICATION_XML)
+            validateResource(ctx.newXmlParser().encodeResourceToString(resource), MediaType.APPLICATION_XML)
 
         Assertions.assertThat(out).isNotNull
         val responseResource = getResource(out)
@@ -104,6 +109,40 @@ class FhirValidatorApplicationTests(@Autowired val restTemplate: TestRestTemplat
         if (responseResource is OperationOutcome) {
 
             Assertions.assertThat(hasErrors(responseResource)).isEqualTo(true)
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun validateHomecareContinuousExample() {
+
+        val resource = getFileResourceJSON("homecare-continuous-example.json")
+        val out: ResponseEntity<*>? =
+            validateResource(ctx.newJsonParser().encodeResourceToString(resource), MediaType.APPLICATION_JSON)
+
+        Assertions.assertThat(out).isNotNull
+        val responseResource = getResource(out)
+        Assertions.assertThat(responseResource).isInstanceOf(OperationOutcome::class.java)
+        if (responseResource is OperationOutcome) {
+
+            Assertions.assertThat(hasErrors(responseResource)).isEqualTo(false)
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun validateDispense1stEventEithDispenser() {
+
+        val resource = getFileResourceJSON("dispense-1st-event-with-dispenser.json")
+        val out: ResponseEntity<*>? =
+            validateResource(ctx.newJsonParser().encodeResourceToString(resource), MediaType.APPLICATION_JSON)
+
+        Assertions.assertThat(out).isNotNull
+        val responseResource = getResource(out)
+        Assertions.assertThat(responseResource).isInstanceOf(OperationOutcome::class.java)
+        if (responseResource is OperationOutcome) {
+
+            Assertions.assertThat(hasErrors(responseResource)).isEqualTo(false)
         }
     }
 

--- a/src/test/kotlin/com/example/fhirvalidator/FhirValidatorApplicationTests.kt
+++ b/src/test/kotlin/com/example/fhirvalidator/FhirValidatorApplicationTests.kt
@@ -1,13 +1,115 @@
 package com.example.fhirvalidator
 
+import ca.uhn.fhir.context.FhirContext
+import com.example.fhirvalidator.service.ImplementationGuideParser
+import mu.KLogging
+import org.assertj.core.api.Assertions
+import org.hl7.fhir.instance.model.api.IBaseResource
+import org.hl7.fhir.r4.model.OperationOutcome
+import org.hl7.fhir.utilities.cache.NpmPackage
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.web.server.LocalServerPort
+import org.springframework.http.*
+import java.io.InputStreamReader
+import java.io.Reader
 
-@SpringBootTest
-class FhirValidatorApplicationTests {
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class FhirValidatorApplicationTests(@Autowired val restTemplate: TestRestTemplate
+) {
+
+    @LocalServerPort
+    private val port = 0
+
+    lateinit var ctx : FhirContext
+
+    companion object : KLogging()
+
+    init {
+        ctx = FhirContext.forR4()
+    }
+
+    private fun getFileResourceXML(fileName: String): IBaseResource? {
+        val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(
+            "FHIRExamples/$fileName"
+        )
+        Assertions.assertThat(inputStream != null).isEqualTo(true)
+        val reader: Reader = InputStreamReader(inputStream)
+        return ctx.newXmlParser().parseResource(reader)
+    }
+
+    private fun getFileResourceJSON(fileName: String): IBaseResource? {
+        val inputStream = Thread.currentThread().contextClassLoader.getResourceAsStream(
+            "FHIRExamples/$fileName"
+        )
+        Assertions.assertThat(inputStream != null).isEqualTo(true)
+        val reader: Reader = InputStreamReader(inputStream)
+        return ctx.newJsonParser().parseResource(reader)
+    }
+
+    private fun validateResource(json: String,mediaType :  MediaType ): ResponseEntity<*>? {
+        val headers = HttpHeaders()
+        headers.contentType = mediaType
+        val entity = HttpEntity<Any>(json, headers)
+        return restTemplate.exchange(
+            "http://localhost:$port/R4/\$validate", HttpMethod.POST, entity,
+            String::class.java
+        )
+    }
+
+    private fun hasErrors(operationOutcome: OperationOutcome) : Boolean {
+        operationOutcome.issue.forEach{
+            if (it.severity == OperationOutcome.IssueSeverity.ERROR) return true
+        }
+        return false
+    }
+    private fun getResource(response : ResponseEntity<*>?): IBaseResource? {
+        if (response != null && response.body != null && response.body is String) {
+            return ctx.newJsonParser().parseResource(response.body as String?)
+        }
+        return null
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun validateMedicationRequestMissingSNOMEDMedcation() {
+
+        val resource = getFileResourceXML("MedicationRequest-missingSNOMEDMedcation.xml")
+        val out: ResponseEntity<*>? =
+            validateResource(ctx.newJsonParser().encodeResourceToString(resource), MediaType.APPLICATION_XML)
+
+        Assertions.assertThat(out).isNotNull
+        val responseResource = getResource(out)
+        Assertions.assertThat(responseResource).isInstanceOf(OperationOutcome::class.java)
+        if (responseResource is OperationOutcome) {
+
+            Assertions.assertThat(hasErrors(responseResource)).isEqualTo(true)
+        }
+    }
+
+    @Test
+    @Throws(Exception::class)
+    fun validateMedicationRequestDuplicateMedicationReferences() {
+
+        val resource = getFileResourceJSON("MedicationRequest-bothMedicationReferenceAndCodeableConcept.json")
+        val out: ResponseEntity<*>? =
+            validateResource(ctx.newJsonParser().encodeResourceToString(resource), MediaType.APPLICATION_JSON)
+
+        Assertions.assertThat(out).isNotNull
+        val responseResource = getResource(out)
+        Assertions.assertThat(responseResource).isInstanceOf(OperationOutcome::class.java)
+        if (responseResource is OperationOutcome) {
+
+            Assertions.assertThat(hasErrors(responseResource)).isEqualTo(true)
+        }
+    }
 
     @Test
     fun contextLoads() {
     }
+
 
 }

--- a/src/test/resources/FHIRExamples/MedicationRequest-bothMedicationReferenceAndCodeableConcept.json
+++ b/src/test/resources/FHIRExamples/MedicationRequest-bothMedicationReferenceAndCodeableConcept.json
@@ -1,0 +1,121 @@
+{
+  "resourceType": "MedicationRequest",
+  "id": "A7B86F8D-1D7C-FC28-E050-D20AE3A215F4",
+  "extension": [
+    {
+      "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionType",
+      "valueCoding": {
+        "system": "https://fhir.nhs.uk/CodeSystem/prescription-type",
+        "code": "0101"
+      }
+    },
+    {
+      "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-ControlledDrug",
+      "extension": [
+        {
+          "url": "quantityWords",
+          "valueString": "twenty eight"
+        },
+        {
+          "url": "schedule",
+          "valueCoding": {
+            "system": "https://fhir.nhs.uk/CodeSystem/medicationrequest-controlled-drug",
+            "code": "CD2",
+            "display": "Schedule 2"
+          }
+        }
+      ]
+    }
+  ],
+  "identifier": [
+    {
+      "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+      "value": "A7B86F8D-1D7C-FC28-E050-D20AE3A215F0"
+    }
+  ],
+  "status": "active",
+  "intent": "order",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+          "code": "outpatient",
+          "display": "Outpatient"
+        }
+      ]
+    }
+  ],
+  "medicationCodeableConcept": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "36126511000001106",
+        "display": "Morphine 10mg modified-release tablets"
+      }
+    ]
+  },
+  "medicationReference": {
+    "reference": "urn:uuid:6cec5ce3-2415-418a-a593-d3928852d5bd"
+  },
+  "subject": {
+    "reference": "urn:uuid:848d8470-bd51-494e-9347-8142ea75cb23"
+  },
+  "authoredOn": "2019-12-30T12:00:00+00:00",
+  "requester": {
+    "reference": "urn:uuid:56166769-c1c4-4d07-afa8-132b5dfca645"
+  },
+  "groupIdentifier": {
+    "extension": [
+      {
+        "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId",
+        "valueIdentifier": {
+          "system": "https://fhir.nhs.uk/Id/prescription",
+          "value": "A7B86F8D-1CF8-FC28-E050-D20AE3A215F0"
+        }
+      }
+    ],
+    "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+    "value": "3C2366-B81001-0A409U"
+  },
+  "courseOfTherapyType": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-course-of-therapy",
+        "code": "acute",
+        "display": "Short course (acute) therapy"
+      }
+    ]
+  },
+  "dosageInstruction": [
+    {
+      "text": "1 tablet, daily"
+    }
+  ],
+  "dispenseRequest": {
+    "extension": [
+      {
+        "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PerformerSiteType",
+        "valueCoding": {
+          "system": "https://fhir.nhs.uk/CodeSystem/dispensing-site-preference",
+          "code": "0004"
+        }
+      }
+    ],
+    "performer": {
+      "identifier": {
+        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+        "value": "FX748"
+      }
+    },
+    "quantity": {
+      "value": 28,
+      "unit": "tablet",
+      "system": "http://snomed.info/sct",
+      "code": "428673006"
+    }
+  },
+  "substitution": {
+    "allowedBoolean": false
+  }
+}

--- a/src/test/resources/FHIRExamples/MedicationRequest-missingSNOMEDMedcation.xml
+++ b/src/test/resources/FHIRExamples/MedicationRequest-missingSNOMEDMedcation.xml
@@ -1,0 +1,79 @@
+<MedicationRequest xmlns="http://hl7.org/fhir">
+    <id value="missingSNOMED-fail"></id>
+    <extension url="https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionType">
+        <valueCoding>
+            <system value="https://fhir.nhs.uk/CodeSystem/prescription-type"></system>
+            <code value="0101"></code>
+            <display value="Primary Care Prescriber – Medical Prescriber"></display>
+        </valueCoding>
+    </extension>
+    <extension url="https://fhir.nhs.uk/StructureDefinition/Extension-DM-ResponsiblePractitioner">
+        <valueReference>
+            <reference value="urn:uuid:1557E58E-3B1E-41DD-B3B5-D4D393DC5A3D"></reference>
+        </valueReference>
+    </extension>
+    <identifier>
+        <system value="https://fhir.nhs.uk/Id/prescription-order-item-number"></system>
+        <value value="1E34EE53-397A-2E70-E97C-67B1BD95014D"></value>
+    </identifier>
+    <status value="active"></status>
+    <intent value="order"></intent>
+    <medicationCodeableConcept>
+        <coding>
+            <system value="https://fhir.hl7.org.uk/Id/multilex-drug-codes"></system>
+            <code value="ABCDE"></code>
+            <display value="Salbutamol 100micrograms inhaler (product)"></display>
+        </coding>
+    </medicationCodeableConcept>
+    <subject>
+        <reference value="urn:uuid:C6750CAA-3CA9-4F29-A282-6EE1AA5D7D4C"></reference>
+    </subject>
+    <authoredOn value="2004-09-20T10:30:00.000+00:00"></authoredOn>
+    <requester>
+        <reference value="urn:uuid:1557E58E-3B1E-41DD-B3B5-D4D393DC5A3D"></reference>
+        <display value="Dr Smith"></display>
+    </requester>
+    <groupIdentifier>
+        <extension url="https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId">
+            <valueIdentifier>
+                <system value="https://fhir.nhs.uk/Id/prescription"></system>
+                <value value="EDD2E9DD-DA0A-C266-A4E3-447C68239524"></value>
+            </valueIdentifier>
+        </extension>
+        <system value="https://fhir.nhs.uk/Id/prescription-order-number"></system>
+        <value value="83C40E-A23856-00123C"></value>
+    </groupIdentifier>
+    <courseOfTherapyType>
+        <coding>
+            <system value="https://fhir.hl7.org.uk/CodeSystem/UKCore-PrescriptionType"></system>
+            <code value="acute"></code>
+            <display value="Short course (acute) therapy"></display>
+        </coding>
+    </courseOfTherapyType>
+    <dosageInstruction>
+        <text value="2 Puffs when required"></text>
+    </dosageInstruction>
+    <dispenseRequest>
+        <extension url="https://fhir.nhs.uk/StructureDefinition/Extension-DM-PerformerSiteType">
+            <valueCoding>
+                <system value="https://fhir.nhs.uk/CodeSystem/dispensing-site-preference"></system>
+                <code value="0004"></code>
+            </valueCoding>
+        </extension>
+        <quantity>
+            <value value="200"></value>
+            <unit value="actuation(s)"></unit>
+            <system value="http://snomed.info/sct"></system>
+            <code value="732981002"></code>
+        </quantity>
+        <performer>
+            <identifier>
+                <system value="https://not.correct.uri/Id/ods-organization-code"></system>
+                <value value="Y12345"></value>
+            </identifier>
+        </performer>
+    </dispenseRequest>
+    <substitution>
+        <allowedBoolean value="false"></allowedBoolean>
+    </substitution>
+</MedicationRequest>

--- a/src/test/resources/FHIRExamples/dispense-1st-event-with-dispenser.json
+++ b/src/test/resources/FHIRExamples/dispense-1st-event-with-dispenser.json
@@ -1,0 +1,339 @@
+{
+  "resourceType": "Bundle",
+  "id": "b240434e-cb85-40bb-899c-1c61410c93a7",
+  "identifier": {
+    "system": "https://tools.ietf.org/html/rfc4122",
+    "value": "b240434e-cb85-40bb-899c-1c61410c93a7"
+  },
+  "type": "message",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:E9A71955-53BA-B15A-D4B6-BEA99D5017B3",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "eventCoding": {
+          "system": "https://fhir.nhs.uk/CodeSystem/message-event",
+          "code": "dispense-notification",
+          "display": "Dispense Notification"
+        },
+        "destination": [
+          {
+            "endpoint": "https://sandbox.api.service.nhs.uk/electronic-prescriptions/$post-message",
+            "receiver": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                "value": "T1450"
+              },
+              "display": "NHS BUSINESS SERVICES AUTHORITY"
+            }
+          }
+        ],
+        "sender": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "VNE51"
+          },
+          "display": "The Simple Pharmacy"
+        },
+        "source": {
+          "name": "The Simple Pharmacy",
+          "endpoint": "urn:nhs-uk:addressing:ods:VNE51"
+        },
+        "reason": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/message-reason-prescription",
+              "code": "notification",
+              "display": "Notification"
+            }
+          ]
+        },
+        "response": {
+          "identifier": "6b1d6d0f-f154-48c9-80e5-48f041585185",
+          "code": "ok"
+        },
+        "focus": [
+          {
+            "reference": "urn:uuid:4509B70D-D8B8-EA03-1105-64557CB54A29"
+          },
+          {
+            "reference": "urn:uuid:06167339-9337-D030-0366-514A6A46DA17"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:4509B70D-D8B8-EA03-1105-64557CB54A29",
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-TaskBusinessStatus",
+            "valueCoding": {
+              "system": "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+              "code": "0003",
+              "display": "With Dispenser - Active"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-dispense-item-number",
+            "value": "fd833d33-f128-4fa2-a807-1fc8a7db2658"
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "1858411000001101",
+              "display": "Paracetamol 500mg soluble tablets (Alliance Healthcare (Distribution) Ltd) 60 tablet"
+            }
+          ]
+        },
+        "subject": {
+          "type": "Patient",
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9876543210"
+          },
+          "display": "Miss Bernie Kanfeld"
+        },
+        "performer": [
+          {
+            "actor": {
+              "type" : "Practitioner",
+              "identifier":  {
+                "system": "https://fhir.hl7.org.uk/Id/gphc-number",
+                "value": "7654321"
+              },
+              "display": "Mr Peter Potion"
+            }
+          },
+          {
+            "actor": {
+              "type": "Organization",
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                "value": "VNE51"
+              },
+              "display": "The Simple Pharmacy"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-GroupIdentifier",
+                "extension": [
+                  {
+                    "url": "shortForm",
+                    "valueIdentifier": {
+                      "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+                      "value": "82D996-C81010-11DB12"
+                    }
+                  },
+                  {
+                    "url": "UUID",
+                    "valueIdentifier": {
+                      "system": "https://fhir.nhs.uk/Id/prescription",
+                      "value": "b2fc79f0-2793-4736-9b2d-0976c21e73a5"
+                    }
+                  }
+                ]
+              }
+            ],
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+              "value": "5cb17f5a-11ac-4e18-825f-6470467238b3"
+            }
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+              "code": "0003",
+              "display": "Item dispensed - partial"
+            }
+          ]
+        },
+        "quantity": {
+          "value": 60,
+          "unit": "tablet",
+          "system": "http://snomed.info/sct",
+          "code": "732936001"
+        },
+        "daysSupply": {
+          "value": 15,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2020-06-10T16:30:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "100 tablets. One tablet to be taken four times a day",
+            "timing": {
+              "repeat": {
+                "frequency": 5,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "26643006",
+                  "display": "Oral"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:06167339-9337-D030-0366-514A6A46DA17",
+      "resource": {
+        "resourceType": "MedicationDispense",
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-EPS-TaskBusinessStatus",
+            "valueCoding": {
+              "system": "https://fhir.nhs.uk/CodeSystem/EPS-task-business-status",
+              "code": "0003",
+              "display": "With Dispenser - Active"
+            }
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-dispense-item-number",
+            "value": "06167339-9337-D030-0366-514A6A46DA17"
+          }
+        ],
+        "status": "completed",
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "3416211000001106",
+              "display": "Salbutamol 100micrograms/dose inhaler (Sandoz Ltd) 200 dose"
+            }
+          ]
+        },
+        "subject": {
+          "type": "Patient",
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9876543210"
+          },
+          "display": "Miss Bernie Kanfeld"
+        },
+        "performer": [
+          {
+            "actor": {
+              "type" : "Practitioner",
+              "identifier":  {
+                "system": "https://fhir.hl7.org.uk/Id/gphc-number",
+                "value": "7654321"
+              },
+              "display": "Mr Peter Potion"
+            }
+          },
+          {
+            "actor": {
+              "type": "Organization",
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                "value": "VNE51"
+              },
+              "display": "The Simple Pharmacy"
+            }
+          }
+        ],
+        "authorizingPrescription": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-GroupIdentifier",
+                "extension": [
+                  {
+                    "url": "shortForm",
+                    "valueIdentifier": {
+                      "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+                      "value": "82D996-C81010-11DB12"
+                    }
+                  },
+                  {
+                    "url": "UUID",
+                    "valueIdentifier": {
+                      "system": "https://fhir.nhs.uk/Id/prescription",
+                      "value": "b2fc79f0-2793-4736-9b2d-0976c21e73a5"
+                    }
+                  }
+                ]
+              }
+            ],
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+              "value": "5cb17f5a-11ac-4e18-825f-6470467238b3"
+            }
+          }
+        ],
+        "type": {
+          "coding": [
+            {
+              "system": "https://fhir.nhs.uk/CodeSystem/medicationdispense-type",
+              "code": "0001",
+              "display": "Item fully dispensed"
+            }
+          ]
+        },
+        "quantity": {
+          "value": 200,
+          "unit": "unit dose",
+          "system": "http://snomed.info/sct",
+          "code": "408102007"
+        },
+        "daysSupply": {
+          "value": 40,
+          "unit": "Day",
+          "system": "http://unitsofmeasure.org",
+          "code": "d"
+        },
+        "whenPrepared": "2004-09-16T16:30:00+00:00",
+        "dosageInstruction": [
+          {
+            "text": "5 times a day for 40 days",
+            "timing": {
+              "repeat": {
+                "boundsDuration": {
+                  "value": 40,
+                  "unit": "d"
+                },
+                "frequency": 5,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 1,
+                  "unit": "unit dose",
+                  "system": "http://snomed.info/sct",
+                  "code": "408102007"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/FHIRExamples/homecare-continuous-example.json
+++ b/src/test/resources/FHIRExamples/homecare-continuous-example.json
@@ -1,0 +1,447 @@
+{
+  "resourceType": "Bundle",
+  "id": "hce-DC2C66-A1B2C3-23407B",
+  "meta": {
+    "lastUpdated": "2020-11-02T01:43:30+00:00"
+  },
+  "identifier": {
+    "system": "https://fhir.nhs.uk/Id/prescription",
+    "value": "ad945a29-85f8-439a-b590-6789719adc16"
+  },
+  "type": "message",
+  "timestamp": "2020-11-02T01:44:30+00:00",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:311316d3-1de0-4f7c-8109-c950ead1c717",
+      "resource": {
+        "resourceType": "MessageHeader",
+        "eventCoding": {
+          "system": "https://fhir.nhs.uk/CodeSystem/message-event",
+          "code": "prescription-order",
+          "display": "Prescription Order"
+        },
+        "destination": [
+          {
+            "endpoint": "https://sandbox.api.service.nhs.uk/electronic-prescriptions/$post-message",
+            "receiver": {
+              "identifier": {
+                "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                "value": "VNE51"
+              },
+              "display": "The Simple Pharmacy"
+            }
+          }
+        ],
+        "sender": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "RBA"
+          },
+          "display": "TAUNTON AND SOMERSET NHS FOUNDATION TRUST"
+        },
+        "author": {
+          "type": "PractitionerRole",
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+            "value": "100102238986"
+          },
+          "display": "DR ALI"
+        },
+        "source": {
+          "endpoint": "urn:nhs-uk:addressing:ods:RBA"
+        },
+        "focus": [
+          {
+            "type": "Patient",
+            "reference": "urn:uuid:78d3c2eb-009e-4ec8-a358-b042954aa9b2"
+          },
+          {
+            "type": "MedicationRequest",
+            "reference": "urn:uuid:a54219b8-f741-4c47-b662-e4f8dfa49ab6"
+          },
+          {
+            "type": "Provenance",
+            "reference": "urn:uuid:28828C55-8FA7-42D7-916F-FCF076E0C10E"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:a54219b8-f741-4c47-b662-e4f8dfa49ab6",
+      "resource": {
+        "resourceType": "MedicationRequest",
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionType",
+            "valueCoding": {
+              "system": "https://fhir.nhs.uk/CodeSystem/prescription-type",
+              "code": "1201",
+              "display": "Outpatient Homecare Prescriber - Medical Prescriber"
+            }
+          },
+          {
+            "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-MedicationRepeatInformation",
+            "extension": [
+              {
+                "url": "numberOfRepeatPrescriptionsAllowed",
+                "valueUnsignedInt": 4
+              },
+              {
+                "url": "numberOfRepeatPrescriptionsIssued",
+                "valueUnsignedInt": 1
+              },
+              {
+                "url": "authorisationExpiryDate",
+                "valueDateTime": "2020-08-07"
+              }
+            ]
+          }
+        ],
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/prescription-order-item-number",
+            "value": "a54219b8-f741-4c47-b662-e4f8dfa49ab6"
+          }
+        ],
+        "status": "active",
+        "intent": "order",
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-category",
+                "code": "outpatient",
+                "display": "Outpatient"
+              }
+            ]
+          }
+        ],
+        "medicationCodeableConcept": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "15517911000001104",
+              "display": "Methotrexate 10mg/0.2ml solution for injection pre-filled syringes"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:78d3c2eb-009e-4ec8-a358-b042954aa9b2"
+        },
+        "authoredOn": "2020-07-13T12:00:00+00:00",
+        "requester": {
+          "reference": "urn:uuid:56166769-c1c4-4d07-afa8-132b5dfca666"
+        },
+        "groupIdentifier": {
+          "extension": [
+            {
+              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PrescriptionId",
+              "valueIdentifier": {
+                "system": "https://fhir.nhs.uk/Id/prescription",
+                "value": "ad945a29-85f8-439a-b590-6789719adc16"
+              }
+            }
+          ],
+          "system": "https://fhir.nhs.uk/Id/prescription-order-number",
+          "value": "DC2C66-A1B2C3-23407B"
+        },
+        "courseOfTherapyType": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/medicationrequest-course-of-therapy",
+              "code": "continuous",
+              "display": "Continuous long term therapy"
+            }
+          ]
+        },
+        "dosageInstruction": [
+          {
+            "text": "10 milligram, Inject, Subcutaneous route, once weekly",
+            "additionalInstruction": [
+              {
+                "coding": [
+                  {
+                    "system": "http://snomed.info/sct",
+                    "code": "421769005",
+                    "display": "Follow directions"
+                  }
+                ]
+              }
+            ],
+            "patientInstruction": "As directed",
+            "timing": {
+              "repeat": {
+                "boundsDuration": {
+                  "value": 10,
+                  "unit": "day",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "d"
+                },
+                "frequency": 5,
+                "period": 1,
+                "periodUnit": "d"
+              }
+            },
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "34206005",
+                  "display": "Subcutaneous route"
+                }
+              ]
+            },
+            "method": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "422145002",
+                  "display": "Inject"
+                }
+              ]
+            },
+            "doseAndRate": [
+              {
+                "doseQuantity": {
+                  "value": 10,
+                  "unit": "milligram",
+                  "system": "http://unitsofmeasure.org",
+                  "code": "mg"
+                }
+              }
+            ]
+          }
+        ],
+        "dispenseRequest": {
+          "extension": [
+            {
+              "url": "https://fhir.nhs.uk/StructureDefinition/Extension-DM-PerformerSiteType",
+              "valueCoding": {
+                "system": "https://fhir.nhs.uk/CodeSystem/dispensing-site-preference",
+                "code": "P2"
+              }
+            }
+          ],
+          "validityPeriod": {
+            "start": "2020-07-13T12:00:00+00:00",
+            "end": "2020-08-07T12:00:00+00:00"
+          },
+          "numberOfRepeatsAllowed": 4,
+          "quantity": {
+            "value": 1,
+            "unit": "pre-filled disposable injection",
+            "system": "http://snomed.info/sct",
+            "code": "3318611000001103"
+          },
+          "expectedSupplyDuration": {
+            "value": 7,
+            "unit": "day",
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+          },
+          "performer": {
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+              "value": "VNE51"
+            }
+          }
+        },
+        "substitution": {
+          "allowedBoolean": false
+        }
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:78d3c2eb-009e-4ec8-a358-b042954aa9b2",
+      "resource": {
+        "resourceType": "Patient",
+        "identifier": [
+          {
+            "extension": [
+              {
+                "url": "https://fhir.hl7.org.uk/StructureDefinition/Extension-UKCore-NHSNumberVerificationStatus",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-NHSNumberVerificationStatus",
+                      "code": "01",
+                      "display": "Number present and verified"
+                    }
+                  ]
+                }
+              }
+            ],
+            "system": "https://fhir.nhs.uk/Id/nhs-number",
+            "value": "9453740519"
+          }
+        ],
+        "name": [
+          {
+            "use": "official",
+            "family": "CORY",
+            "given": [
+              "ETTA"
+            ],
+            "prefix": [
+              "MISS"
+            ]
+          }
+        ],
+        "gender": "female",
+        "birthDate": "1999-01-04",
+        "address": [
+          {
+            "use": "home",
+            "line": [
+              "123 Dale Avenue",
+              "Long Eaton",
+              "Nottingham"
+            ],
+            "postalCode": "NG10 1NP"
+          }
+        ],
+        "generalPractitioner": [
+          {
+            "identifier": {
+              "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+              "value": "B81001"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:56166769-c1c4-4d07-afa8-132b5dfca666",
+      "resource": {
+        "resourceType": "PractitionerRole",
+        "identifier": [
+          {
+            "system": "https://fhir.nhs.uk/Id/sds-role-profile-id",
+            "value": "100102238986"
+          },
+          {
+            "system": "https://fhir.hl7.org.uk/Id/nhsbsa-spurious-code",
+            "value": "G6345213"
+          }
+        ],
+        "practitioner": {
+          "identifier": {
+            "system": "https://fhir.hl7.org.uk/Id/gmc-number",
+            "value": "C1234567"
+          },
+          "display": "DR RAZIA ALI"
+        },
+        "organization": {
+          "identifier": {
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "RBA"
+          },
+          "display": "TAUNTON AND SOMERSET NHS FOUNDATION TRUST"
+        },
+        "specialty": [
+          {
+            "coding": [
+              {
+                "system": "https://fhir.nhs.uk/CodeSystem/NHSDataModelAndDictionary-clinical-specialty",
+                "code": "370",
+                "display": "MEDICAL ONCOLOGY"
+              }
+            ]
+          }
+        ],
+        "code": [
+          {
+            "coding": [
+              {
+                "system": "https://fhir.hl7.org.uk/CodeSystem/UKCore-SDSJobRoleName",
+                "code": "R8000",
+                "display": "Clinical Practitioner Access Role"
+              }
+            ]
+          }
+        ],
+        "location": [
+          {
+            "reference": "urn:uuid:044e7916-c697-4072-880e-ef44d3032962",
+            "display": "MUSGROVE PARK HOSPITAL"
+          }
+        ],
+        "healthcareService": [
+          {
+            "identifier": {
+              "use": "official",
+              "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+              "value": "A99968"
+            },
+            "display": "SOMERSET BOWEL CANCER SCREENING CENTRE"
+          }
+        ],
+        "telecom": [
+          {
+            "system": "phone",
+            "value": "01234567890",
+            "use": "work"
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:28828C55-8FA7-42D7-916F-FCF076E0C10E",
+      "resource": {
+        "resourceType": "Provenance",
+        "target": [
+          {
+            "reference": "urn:uuid:a54219b8-f741-4c47-b662-e4f8dfa49ab6"
+          }
+        ],
+        "recorded": "2008-02-27T11:38:00+00:00",
+        "agent": [
+          {
+            "who": {
+              "reference": "urn:uuid:56166769-c1c4-4d07-afa8-132b5dfca666"
+            }
+          }
+        ],
+        "signature": [
+          {
+            "type": [
+              {
+                "system": "urn:iso-astm:E1762-95:2013",
+                "code": "1.2.840.10065.1.12.1.1"
+              }
+            ],
+            "when": "2020-09-02T11:38:00+00:00",
+            "who": {
+              "reference": "urn:uuid:56166769-c1c4-4d07-afa8-132b5dfca666"
+            },
+            "data": "PFNpZ25hdHVyZSB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnIyI+PFNpZ25lZEluZm8+PENhbm9uaWNhbGl6YXRpb25NZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiLz48U2lnbmF0dXJlTWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMC8wOS94bWxkc2lnI3JzYS1zaGExIi8+PFJlZmVyZW5jZT48VHJhbnNmb3Jtcz48VHJhbnNmb3JtIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS8xMC94bWwtZXhjLWMxNG4jIi8+PC9UcmFuc2Zvcm1zPjxEaWdlc3RNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjc2hhMSIvPjxEaWdlc3RWYWx1ZT4zWWxGUU1PcncyUTBkVWt5dHpzNTBKRjdIVW89PC9EaWdlc3RWYWx1ZT48L1JlZmVyZW5jZT48L1NpZ25lZEluZm8+PFNpZ25hdHVyZVZhbHVlPlhwanNLWFBmVVc3MDhyR1B1T0FwaGxyNC9VQTIzZjNiaGRCT29jRUoxN0JYVjBKcnV6MUUxS0xGUXdxMzdFSmZuVm8vV0NMVFNqZ2sKa3AwQldqNWJHM0pqRWZqNzhaakkxeVZTUmJmYlZYWFFYMEdMWm1pU0dKcmhXbkZadDhjRnJ4TzFNRkF0U0xtS2Z5WEt6YnVIc0xUbQpzSFFLcFhDUmRabkZtS0JvakxtcDdOQnIwbExFOFBodHR1OEYyRWFldTJ3UFE4NHAxaU5XOTFmbzFIK1NGVnhDK0JSb1BJMXBvbFhnCjQyY2VUam9KNytGcVlQREhmQzduTkZJZ1RZSlpsUWRib01OYm5kdjZCUER1RnEwd3VzUWpEUTR6TVorOENscFJkdDNpS215bFhObUsKa0pBMTVXMHBGYkdxMFhuZjNTMU1YV0Vsa2FDSVVDZEdLMldzUEE9PTwvU2lnbmF0dXJlVmFsdWU+PEtleUluZm8+PFg1MDlEYXRhPjxYNTA5Q2VydGlmaWNhdGU+TUlJRUpEQ0NBd3lnQXdJQkFnSVVLM3hrRVVsUmhYUEpLTlZ3cnlxTFpSb05UUVF3RFFZSktvWklodmNOQVFFTEJRQXdSREVPTUF3RwpBMVVFQ2hNRlNGTkRTVU14RVRBUEJnTlZCQXNUQ0U5d1pXNTBaWE4wTVI4d0hRWURWUVFERXhaRlVGTWdUbTl1TFhKbGNIVmthV0YwCmFXOXVJRU5CTUI0WERUSXdNREl5TnpFek1EY3lNbG9YRFRJeU1ESXlOakV6TURjeU1sb3dPekVPTUF3R0ExVUVDaE1GU0ZORFNVTXgKR3pBWkJnTlZCQXNURWxOdmJIVjBhVzl1SUVGemMzVnlZVzVqWlRFTU1Bb0dBMVVFQXhNRFJVMVZNSUlCSWpBTkJna3Foa2lHOXcwQgpBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFwMEc0R2FjN1MwbXFsSFkvc1crRUZaWkw4QVUrRk1SclNGSWVmSVNvY0E2RHNIZVBnSHBnCjB0SmNkbWozTjQ1VlI2RkhEckt4NURnLzAwNVIvdDhnYnVJSEYraUkxcHVUY1Y5aldQbWFra3VybFZQQVJtaUF5NzY3V1BrOW1wVW8KbGZvSGRJTEtxZklXTXpRelc3QzRMOHZGSzU1QkllVjQvbElEdkVweForTEhXYmttay9oMWRXZXh1cGpPVGZxVG4vVWl4K0xhdDJUcApxellTck0wYmVwOHA4dWNuZE41c3FjbTZVa1BvdGhzeE5FaTJIamtkOGFvSDFINEtJVndnY0J3V2UrWHJMWEs1V2FyTVcwWTlxZ1FLCnhNc252VzhveUhhODNta0hZK2U4T2VOL1NucVlqa2FnMEk0cHZiQlRjbHJHZklTY0lmVFpvclZuMld2Q0lRSURBUUFCbzRJQkZUQ0MKQVJFd0NRWURWUjBUQkFJd0FEQU9CZ05WSFE4QkFmOEVCQU1DQmFBd0lBWURWUjBsQVFIL0JCWXdGQVlJS3dZQkJRVUhBd0VHQ0NzRwpBUVVGQndNQ01EWUdDV0NHU0FHRytFSUJEUVFwRmlkUGNHVnVkR1Z6ZERvZ1QzQmxibE5UVENCSFpXNWxjbUYwWldRZ1EyVnlkR2xtCmFXTmhkR1V3SFFZRFZSME9CQllFRkFINHB0Y2tPaHNVekJmVmp0L20wNUdpTzhYUk1Ic0dBMVVkSXdSME1IS0FGTklSdlg5b21ybDcKWlhTcUVJTnk2dzJyUFFkdW9VK2tUVEJMTVJRd0VnWURWUVFLRXd0T1NGTWdSR2xuYVhSaGJERVJNQThHQTFVRUN4TUlUM0JsYm5SbApjM1F4SURBZUJnTlZCQU1URjA5d1pXNTBaWE4wSUZKdmIzUWdRWFYwYUc5eWFYUjVnZ2tBNnUwY1hiTHFLb1F3RFFZSktvWklodmNOCkFRRUxCUUFEZ2dFQkFFRGNyUGNkcklDNXVmVkhyYTYyb0dCUC9sejVvSnEzUWw5M1BoZ3c5QkRidW1QVTc0UCtYZ1FvTzl2dzh4TzIKWWI0K1BMN00yQnVKbzNmRHFjRHNXKzRCNHQ5bWRoV1c3bFJqTjNXY3Vqb0xzbFB6MjNjZnl4Q2dabllNTURiT2hCckp4VkN6WWVDNgpueDZPaGtMMVYzWW9lK09JeXJSZVV6cHplQndzVVg1cTgwMmROYVYxeXJiNmFpMmljZ3hxcFkrZk9aWUZMUmVmUElxdXRCSzczaG5ECnV4RGpJKzdlaHlGcGFwZk9YVkJtTFRhY0x4TEYxRHkvNytHSVhiZEl3YmVkZXQ0cDJJY0VhUlgwZVdUMFUvL1pKU2VCcW5PT3BYbzYKNERmWnRTOVZsMmV4SGJISHFZYzBSVk5wS0ltYVdWck15ZEMxcU9leGpVWlNWQlZkK1pvPTwvWDUwOUNlcnRpZmljYXRlPjwvWDUwOURhdGE+PC9LZXlJbmZvPjwvU2lnbmF0dXJlPg=="
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:044e7916-c697-4072-880e-ef44d3032962",
+      "resource": {
+        "resourceType": "Location",
+        "identifier": [
+          {
+            "use": "official",
+            "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+            "value": "RBA11"
+          }
+        ],
+        "status": "active",
+        "mode": "instance",
+        "address": {
+          "use": "work",
+          "line": [
+            "MUSGROVE PARK HOSPITAL"
+          ],
+          "city": "TAUNTON",
+          "postalCode": "TA1 5DA",
+          "country": "NLD"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,4 +2,4 @@ server.port=9001
 server.tomcat.threads.max=10
 management.endpoints.web.exposure.include=*
 
-ig.packagedownload=false
+ig.packagedownload=true

--- a/src/test/resources/manifest.json
+++ b/src/test/resources/manifest.json
@@ -1,17 +1,14 @@
 [
   {
     "packageName": "uk.nhsdigital.medicines.r4",
-    "version": "2.1.14-alpha",
-    "download": true
+    "version": "2.1.37-alpha"
   },
   {
     "packageName": "uk.nhsdigital.r4",
-    "version": "2.1.16-discovery",
-    "download": true
+    "version": "2.1.33-discovery"
   },
   {
     "packageName": "UK.Core.r4.v2",
-    "version": "2.0.8",
-    "download": true
+    "version": "2.0.8"
   }
 ]

--- a/src/test/resources/manifest.json
+++ b/src/test/resources/manifest.json
@@ -2,16 +2,16 @@
   {
     "packageName": "uk.nhsdigital.medicines.r4",
     "version": "2.1.14-alpha",
-    "download": false
+    "download": true
   },
   {
     "packageName": "uk.nhsdigital.r4",
     "version": "2.1.16-discovery",
-    "download": false
+    "download": true
   },
   {
     "packageName": "UK.Core.r4.v2",
     "version": "2.0.8",
-    "download": false
+    "download": true
   }
 ]


### PR DESCRIPTION
Moved to HAPI RESTful Server.

NOTE Validator endpoint is now on /R4, _status remains on / 
Added basic tests to check validator is validating correctly
NOTE Validator accepts XML as per NHS Digital policy
Validator can be configured to download packages via properties setting (this is default for tests, main works as before)
FHIR Validation is now strict, changed from lenient
The package uk.nhsdigital.clinical.r4 has been removed (content of that package is now in uk.nhsdigital.r4
