### PR TITLE
Aea 1805 stop multiple profile validation

### DIFF
--- a/src/main/kotlin/com/example/fhirvalidator/controller/ValidateController.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/controller/ValidateController.kt
@@ -50,11 +50,12 @@ class ValidateController(
     }
 
     fun validateResource(resource: IBaseResource): OperationOutcome? {
+        // KGM changed order so message defintion will override profiles added by capability statement
+        capabilityStatementApplier.applyCapabilityStatementProfiles(resource)
         val messageDefinitionErrors = messageDefinitionApplier.applyMessageDefinition(resource)
         if (messageDefinitionErrors != null) {
             return messageDefinitionErrors
         }
-        capabilityStatementApplier.applyCapabilityStatementProfiles(resource)
         return validator.validateWithResult(resource).toOperationOutcome() as? OperationOutcome
     }
 

--- a/src/main/kotlin/com/example/fhirvalidator/util/ProfileApplier.kt
+++ b/src/main/kotlin/com/example/fhirvalidator/util/ProfileApplier.kt
@@ -21,5 +21,8 @@ fun getResourcesOfType(resource: IBaseResource, resourceType: String?): List<IBa
 fun applyProfile(resources: List<IBaseResource>, profile: IPrimitiveType<String>) {
     resources.stream()
         .filter { !it.meta.profile.contains(profile) }
-        .forEach { it.meta.addProfile(profile.value) }
+        .forEach {
+            // Only one profile to be used for validation. This is set by capabilityStatement and MessageDefinitions
+            it.meta.profile.clear();
+            it.meta.addProfile(profile.value) }
 }

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -9,6 +9,6 @@
   },
   {
     "packageName": "uk.nhsdigital.medicines.r4.test",
-    "version": "2.3.2-prerelease"
+    "version": "2.3.3-prerelease"
   }
 ]

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,14 +1,14 @@
 [
   {
-    "packageName": "uk.nhsdigital.medicines.r4",
-    "version": "2.2.1"
-  },
-  {
-    "packageName": "uk.nhsdigital.r4",
-    "version": "2.2.0"
-  },
-  {
     "packageName": "UKCore.Release1.test",
-    "version": "1.2.0-prerelease"
+    "version": "1.2.1-prerelease"
+  },
+  {
+    "packageName": "uk.nhsdigital.r4.test",
+    "version": "2.3.5-prerelease"
+  },
+  {
+    "packageName": "uk.nhsdigital.medicines.r4.test",
+    "version": "2.3.2-prerelease"
   }
 ]


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/AEA-1805

Changed order profiles are applied.
Only one profile will be used so if a resource has profile in both the CapabilityStatement and a MessageDefinition.
The MessageDefinition profile will be used.
See ticket for examples currently being failed by validator

Updated Implementation Guide versiosn.