### PR TITLE
Update: [AEA-4443] - Bump FHIR R4 spec

### DIFF
--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -5,10 +5,10 @@
   },
   {
     "packageName": "uk.nhsdigital.r4.test",
-    "version": "2.8.21-prerelease"
+    "version": "2.10.0-prerelease"
   },
   {
     "packageName": "uk.nhsdigital.medicines.r4.test",
-    "version": "2.8.21-prerelease"
+    "version": "2.10.0-prerelease"
   }
 ]

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -5,7 +5,7 @@
   },
   {
     "packageName": "uk.nhsdigital.r4.test",
-    "version": "2.10.0-prerelease"
+    "version": "2.10.1-prerelease"
   },
   {
     "packageName": "uk.nhsdigital.medicines.r4.test",

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -9,6 +9,6 @@
   },
   {
     "packageName": "uk.nhsdigital.medicines.r4.test",
-    "version": "2.10.0-prerelease"
+    "version": "2.8.21-prerelease"
   }
 ]


### PR DESCRIPTION
## Summary

- Routine Change

### Details

In ticket [4443](), we alter the GP practitioner field to be auto-populated if it is not present. However, the current version of the FHIR spec used by the validator does not allow for this field to be empty. This PR will bump the spec to the latest version.